### PR TITLE
Initialize application with sample data

### DIFF
--- a/frontend/src/components/RestaurantCard.js
+++ b/frontend/src/components/RestaurantCard.js
@@ -8,7 +8,7 @@ const RestaurantCard = ({ restaurant }) => {
 		<Card sx={{ borderRadius: 2, overflow: 'hidden', transition: 'box-shadow .2s ease', '&:hover': { boxShadow: 3 } }}>
 			<CardActionArea component={Link} to={`/restaurant/${restaurant.id}`}>
 				<Box sx={{ position: 'relative' }}>
-					<CardMedia component="img" height="160" image={restaurant.imageUrl} alt={restaurant.name} />
+					<CardMedia component="img" height="160" image={restaurant.imageUrl || 'https://via.placeholder.com/600x400?text=Restaurant'} alt={restaurant.name} onError={(e) => { e.target.onerror = null; e.target.src = 'https://via.placeholder.com/600x400?text=Restaurant'; }} />
 					<Chip size="small" label={`${restaurant.rating} ★`} sx={{ position: 'absolute', right: 8, bottom: 8, bgcolor: 'background.paper' }} />
 				</Box>
 				<CardContent>

--- a/frontend/src/pages/RestaurantDetail.js
+++ b/frontend/src/pages/RestaurantDetail.js
@@ -66,7 +66,7 @@ const RestaurantDetail = () => {
 						restaurant && (
 							<Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
 								<Box sx={{ width: 72, height: 72, overflow: 'hidden', borderRadius: 2 }}>
-									<img src={restaurant.imageUrl} alt={restaurant.name} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+									<img src={restaurant.imageUrl || 'https://via.placeholder.com/128?text=Restaurant'} alt={restaurant.name} style={{ width: '100%', height: '100%', objectFit: 'cover' }} onError={(e) => { e.target.onerror = null; e.target.src = 'https://via.placeholder.com/128?text=Restaurant'; }} />
 								</Box>
 								<Box>
 									<Typography variant="h4" sx={{ fontWeight: 800 }}>{restaurant.name}</Typography>
@@ -97,7 +97,7 @@ const RestaurantDetail = () => {
 								{items.map(item => (
 									<Grid item xs={12} sm={6} key={item.id}>
 										<Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-											<CardMedia component="img" height="140" image={item.imageUrl} alt={item.name} />
+											<CardMedia component="img" height="140" image={item.imageUrl || 'https://via.placeholder.com/400x300?text=Dish'} alt={item.name} onError={(e) => { e.target.onerror = null; e.target.src = 'https://via.placeholder.com/400x300?text=Dish'; }} />
 											<CardContent sx={{ flexGrow: 1 }}>
 												<Typography variant="h6" sx={{ fontWeight: 700 }}>{item.name}</Typography>
 												<Typography variant="body2" color="text.secondary" noWrap>{item.description}</Typography>


### PR DESCRIPTION
Add fallback images to restaurant and menu item cards to prevent broken image icons when `imageUrl` is missing or fails to load.

---
<a href="https://cursor.com/background-agent?bcId=bc-df8ec2c9-1dfb-42f5-b77b-b47b31614fca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df8ec2c9-1dfb-42f5-b77b-b47b31614fca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

